### PR TITLE
Setup GH Action to support multi-arch for cilium/packaging

### DIFF
--- a/.github/workflows/build_container.yml
+++ b/.github/workflows/build_container.yml
@@ -1,0 +1,20 @@
+name: build container
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  # build multi-arch images
+  jobs-build-images:
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Login to Quay.io Registry
+      run: docker login -u=${{ secrets.DOCKERHUB_USERNAME }} -p=${{ secrets.DOCKERHUB_PASSWORD }} quay.io
+
+    - name: build multi-arch image
+      run: ./build_container/docker_build.sh `date +'%Y-%m-%d'`

--- a/build_container/docker_build.sh
+++ b/build_container/docker_build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -ex
+
+IMAGE_TAG=${1:-latest}
+DOCKER_REPOSITORY=${2:-cilium}
+DOCKER_REGISTRY=${3:-quay.io}
+IMAGE_ARCH=("amd64" "arm64")
+
+SCRIPTS_DIR=$(dirname "${BASH_SOURCE[0]}")
+
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+docker buildx rm  multi-builder | true
+docker buildx create --use --name multi-builder --platform linux/arm64,linux/amd64
+docker buildx build --platform linux/amd64,linux/arm64  --push -f ${SCRIPTS_DIR}/../Dockerfile.bpftool . -t ${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/cilium-bpftool:${IMAGE_TAG}
+docker buildx build --platform linux/amd64,linux/arm64  --push -f ${SCRIPTS_DIR}/../Dockerfile.iproute2 . -t ${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/cilium-iproute2:${IMAGE_TAG}
+docker buildx build --platform linux/amd64,linux/arm64  --push -f ${SCRIPTS_DIR}/../Dockerfile.llvm . -t ${DOCKER_REGISTRY}/${DOCKER_REPOSITORY}/cilium-llvm:${IMAGE_TAG}


### PR DESCRIPTION
Enable "GitHub-hosted runners + buildx" to build multi-arch image;
Create script support build images and push manifest.

secrets.DOCKERHUB_USERNAME: repository  user
secrets.DOCKERHUB_PASSWORD: repository  password
Be set from Settings->Secrets->Add a new secret.

Signed-off-by: Jianlin Lv <Jianlin.Lv@arm.com>