### PR TITLE
cilium, bpftool: pull in latest changes from bpf-next

### DIFF
--- a/Dockerfile.bpftool
+++ b/Dockerfile.bpftool
@@ -14,7 +14,7 @@ RUN apt-get update && \
       git ca-certificates binutils build-essential libelf-dev python3 && \
     git clone -b master git://git.kernel.org/pub/scm/linux/kernel/git/bpf/bpf-next.git linux && \
     cd linux/tools/bpf/bpftool/ && \
-    git checkout -b 115506fea499f1cd9a80290b31eca4352e0559e9 115506fea499f1cd9a80290b31eca4352e0559e9 && \
+    git checkout -b dda18a5c0b75461d1ed228f80b59c67434b8d601 dda18a5c0b75461d1ed228f80b59c67434b8d601 && \
     git --no-pager remote -v && \
     git --no-pager log -1 && \
     make -j `getconf _NPROCESSORS_ONLN` && \


### PR DESCRIPTION
For CONFIG_HZ and getpeername hook.

Signed-off-by: Daniel Borkmann <daniel@iogearbox.net>